### PR TITLE
Added one time watcher to format promised data

### DIFF
--- a/src/directives/mask.js
+++ b/src/directives/mask.js
@@ -69,13 +69,14 @@ angular.module('ngMask')
             controller.$parsers.push(parser);
             
             // register the watch to observe remote loading or promised data
-           var $watcher = $scope.$watch($attrs.ngModel, function (newValue, oldValue) {
+            var $watcher = $scope.$watch($attrs.ngModel, function (newValue, oldValue) {
+
                 // empty data, loaded after some promise are resolved.
                 if (angular.isUndefined(oldValue) && angular.isDefined(newValue)) {
                     parser(newValue);
                     $watcher();
                 }
-  
+
                 // start input value with some data from controller.
                 if (angular.isDefined(oldValue) && angular.isDefined(newValue)) {
                     parser(newValue);


### PR DESCRIPTION
When I load the input ngModel from promised service, I noticed that the value are not formatted to the input.

Added one time watcher to promised data for cases that ngModel is loaded remotely or resolved by promises.
The watcher is cancelled after first valid call.

Please check if this pull request are valid for the project.
