### PR TITLE
Fix a problem watching ngModel

### DIFF
--- a/src/directives/mask.js
+++ b/src/directives/mask.js
@@ -158,7 +158,7 @@
 
                 // Register the watch to observe remote loading or promised data
                 // Deregister calling returned function
-                var watcher = $scope.$watch($scope.ngModel, function (newValue, oldValue) {
+                var watcher = $scope.$watch('ngModel', function (newValue, oldValue) {
                   if (angular.isDefined(newValue)) {
                     parseViewValue(newValue);
                     watcher();


### PR DESCRIPTION
This line (mask.js:161) was giving me problems because $watch expects a string representing an identifier, however the value of ngModel were given instead of the identifier 'ngModel'. I dont know if this is a angular version related problem (I'm on AngularJS v1.3.14). Thanks for this directive, great job.