### PR TITLE
Fix bad state on 1st character where model != view

### DIFF
--- a/src/directives/mask.js
+++ b/src/directives/mask.js
@@ -69,6 +69,7 @@
                 var options = maskService.getOptions();
 
                 function parseViewValue(value) {
+                  var untouchedValue = value;
                   // set default value equal 0
                   value = value || '';
 
@@ -125,7 +126,7 @@
 
                     // Set validity
                     if (options.validate && controller.$dirty) {
-                      if (fullRegex.test(viewValueWithDivisors) || controller.$isEmpty(controller.$modelValue)) {
+                      if (fullRegex.test(viewValueWithDivisors) || controller.$isEmpty(untouchedValue)) {
                         controller.$setValidity('mask', true);
                       } else {
                         controller.$setValidity('mask', false);


### PR DESCRIPTION
When marking the input as mask-valid or mask-invalid, parseViewValue is checking to see if modelValue is empty, instead of checking to see if the proposed viewValue is empty.

This can cause the field to be marked as valid when the model is currently empty, but the proposed view value is invalid.

I've changed the parseViewValue function to now check that the 'value' from parseViewValue(value) is empty instead of checking the model value.