### PR TITLE
Updated removeWrongPositions to use for instead of for...in

### DIFF
--- a/src/services/maskService.js
+++ b/src/services/maskService.js
@@ -372,7 +372,7 @@
           var wrongPositions = getWrongPositions(viewValueWithDivisors, false);
           var newViewValue = viewValueWithDivisors;
 
-          for (var i in wrongPositions) {
+          for(var i = 0; i < wrongPositions.length; i++){
             var wrongPosition = wrongPositions[i];
             var viewValueArray = viewValueWithDivisors.split('');
             viewValueArray.splice(wrongPosition, 1);


### PR DESCRIPTION
- Removed a foreach style loop in the removeWrongPositions function in favor of a for loop.
- This resolves issue #40; which caused masks in projects where Arrays had additional properties to fail with restrict set to reject