### PR TITLE
Fixed exception when used ngMask with ngAttr

### DIFF
--- a/src/directives/mask.js
+++ b/src/directives/mask.js
@@ -44,6 +44,8 @@
 
           return {
             pre: function($scope, $element, $attrs, controller) {
+              if (!promisse)
+                return;
               promise = maskService.generateRegex({
                 mask: $attrs.mask,
                 // repeat mask expression n times

--- a/src/services/maskService.js
+++ b/src/services/maskService.js
@@ -111,6 +111,9 @@
             var mask = opts['mask'];
             var repeat = opts['repeat'];
 
+            if (!mask)
+              return;
+
             if (repeat) {
               mask = Array((parseInt(repeat)+1)).join(mask);
             }


### PR DESCRIPTION
When I tryied to use ng-attr-ng-mask I've received an exception because
ngMask is undefined. I'm not 100% sure if is it the best way to fix, but, for me is now working.
![error](https://cloud.githubusercontent.com/assets/11821650/8849663/dafc34f6-3117-11e5-93ac-92afd16af89a.JPG)
