### PR TITLE
mask input if model was changed remote

### DIFF
--- a/src/directives/mask.js
+++ b/src/directives/mask.js
@@ -163,11 +163,9 @@
                 });
 
                 // Register the watch to observe remote loading or promised data
-                // Deregister calling returned function
-                var watcher = $scope.$watch($attrs.ngModel, function (newValue, oldValue) {
+                $scope.$watch($attrs.ngModel, function (newValue, oldValue) {
                   if (angular.isDefined(newValue)) {
                     parseViewValue(newValue);
-                    watcher();
                   }
                 });
 


### PR DESCRIPTION
fix issue https://github.com/candreoliveira/ngMask/issues/62

If it broke some cases you need parseViewValue only if model was changed remote (from the outside directive). Simple way: check if masked input is not focused.