### PR TITLE
Added support for Browserify/Webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dist/ngMask.js');
+module.exports = 'ngMask';

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.1",
   "description": "Angular mask without dependencies (NO JQUERY). Pure javascript and only ~6kb! It gives you power to create your mask with optional fields in accordance with your business.",
   "homepage": "https://github.com/candreoliveira/ngMask",
-  "main": "dist/ngMask.js",
+  "main": "index.js",
   "keywords": [
     "angular",
     "mask",


### PR DESCRIPTION
This small approach simplify the call when use webpack.

```
...
import Mask from 'ng-mask';
...

const root = angular
  .module('app', [
    ...
    Mask,
    ...
  ])
  .name;

export default root;
```