### PR TITLE
Fix issue transclude

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ngMask",
-  "version": "3.0.16",
+  "version": "3.0.16.1",
   "homepage": "https://github.com/candreoliveira/ngMask",
   "authors": [
     "Carlos Oliveira <candreoliveira@gmail.com>"

--- a/src/directives/mask.js
+++ b/src/directives/mask.js
@@ -15,7 +15,7 @@
           var timeout;
           var promise;
 
-          function setSelectionRange(selectionStart){
+          function setSelectionRange($element, selectionStart){
             if (typeof selectionStart !== 'number') {
               return;
             }
@@ -108,7 +108,7 @@
 
                         var wrongPosition = maskService.getFirstWrongPosition(viewValueWithDivisors);
                         if (angular.isDefined(wrongPosition)) {
-                          setSelectionRange(wrongPosition);
+                          setSelectionRange($element, wrongPosition);
                         }
                       } else if (options.restrict === 'reject' && !validCurrentPosition) {
                         viewValue = maskService.removeWrongPositions(viewValueWithDivisors);


### PR DESCRIPTION
When use mask directive within other directive that has transclude, with restrict "select", the mask won't work probably especially in IOS safari browser, the reason of that, when we want to select the range in function (setSelectionRange) this function uses the element of compile function, but we need the new element that "post" function has.
post and compile function haven't the same ($element) when using mask inside transclude.