### PR TITLE
Switching $log.info to $log.error

### DIFF
--- a/src/directives/mask.js
+++ b/src/directives/mask.js
@@ -7,7 +7,7 @@
         require: 'ngModel',
         compile: function($element, $attrs) { 
          if (!$attrs.mask || !$attrs.ngModel) {
-            $log.info('Mask and ng-model attributes are required!');
+            $log.error('Mask and ng-model attributes are required!');
             return;
           }
 


### PR DESCRIPTION
Hi, thanks for creating this plugin it has been immensely useful in my application. During usage missed on the ng-model required attribute and didn't notice the info log in console. I have switched to $log.error instead, it may help other poor souls like me :)